### PR TITLE
Fix LocationMediaMessageProtocolEntity attribute

### DIFF
--- a/yowsup/demos/echoclient/layer.py
+++ b/yowsup/demos/echoclient/layer.py
@@ -29,7 +29,7 @@ class EchoLayer(YowInterfaceLayer):
             print("Echoing image %s to %s" % (messageProtocolEntity.url, messageProtocolEntity.getFrom(False)))
 
         elif messageProtocolEntity.media_type == "location":
-            print("Echoing location (%s, %s) to %s" % (messageProtocolEntity.getLatitude(), messageProtocolEntity.getLongitude(), messageProtocolEntity.getFrom(False)))
+            print("Echoing location (%s, %s) to %s" % (messageProtocolEntity.degrees_latitude, messageProtocolEntity.degrees_longitude, messageProtocolEntity.getFrom(False)))
 
         elif messageProtocolEntity.media_type == "contact":
-            print("Echoing contact (%s, %s) to %s" % (messageProtocolEntity.getName(), messageProtocolEntity.getCardData(), messageProtocolEntity.getFrom(False)))
+            print("Echoing contact (%s, %s) to %s" % (messageProtocolEntity.display_name, messageProtocolEntity.vcard, messageProtocolEntity.getFrom(False)))

--- a/yowsup/layers/protocol_media/protocolentities/message_media_location.py
+++ b/yowsup/layers/protocol_media/protocolentities/message_media_location.py
@@ -13,7 +13,7 @@ class LocationMediaMessageProtocolEntity(MediaMessageProtocolEntity):
 
     @property
     def media_specific_attributes(self):
-        return self.message_attributes.contact
+        return self.message_attributes.location
 
     @property
     def degrees_latitude(self):
@@ -41,7 +41,7 @@ class LocationMediaMessageProtocolEntity(MediaMessageProtocolEntity):
 
     @property
     def address(self):
-        return self.proto.addrees
+        return self.media_specific_attributes.address
 
     @address.setter
     def address(self, value):


### PR DESCRIPTION
When you try to code the onMessage handle and the message type is location media, you'll get error to get that location media attribute because the attribute name list was wrongly taken from contact attribute